### PR TITLE
Remove unused LongboardTracks

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -39,11 +39,8 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
-	public function getTracks($lat_from,$lng_from,$lat_to,$lng_to){
-		if($this->id==2){
-			$lt=new \App\LongboardTracks;
-			return $lt->get_tracks($lat_from,$lng_from,$lat_to,$lng_to);
-		}
-		return \App\Models\Track::where('uid',$this->id)->get();
-	}
+        public function getTracks($lat_from, $lng_from, $lat_to, $lng_to)
+        {
+                return \App\Models\Track::where('uid', $this->id)->get();
+        }
 }


### PR DESCRIPTION
## Summary
- remove `LongboardTracks` dependency and the conditional around it
- simplify `User::getTracks` to just return user track records

## Testing
- `php -l app/Models/User.php` *(fails: command not found)*
- `composer -V` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ebb20c34832bbf8143f72c8fe608