### PR TITLE
Fix argument order in getTracks call

### DIFF
--- a/app/Http/Controllers/MapRendererController.php
+++ b/app/Http/Controllers/MapRendererController.php
@@ -116,7 +116,7 @@ class MapRendererController extends Controller
 		$draw->setFillColor(new \ImagickPixel('transparent'));
 		
 		
-		$tracks = $user->getTracks($lat_from,$lng_from,$lng_from,$lng_to);
+                $tracks = $user->getTracks($lat_from,$lng_from,$lat_to,$lng_to);
 		$has_tracks=false;
 		foreach($tracks as $k=>$track){
 			$lines=$track->get_tracks();


### PR DESCRIPTION
## Summary
- call `User::getTracks` with `lat_to` as the third argument instead of `lng_from`

## Testing
- `./vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6843ecbb097c832bbc604ff0fc7a746f